### PR TITLE
remove box sizing to make the border flexible

### DIFF
--- a/styles/dark.css
+++ b/styles/dark.css
@@ -117,7 +117,6 @@ p{
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    box-sizing: border-box;
 }
 .qrText{
     padding-bottom: 0;

--- a/styles/light.css
+++ b/styles/light.css
@@ -112,7 +112,6 @@ p{
     flex-direction: column;
     align-items: center;
     justify-content: center;
-    box-sizing: border-box;
 }
 .qrText{
     padding-bottom: 0;
@@ -212,4 +211,3 @@ p{
         max-width: 8.5cm;
     }
 }
-


### PR DESCRIPTION
related https://github.com/monaashour/DigitalBusinessCard/pull/1

The Content of the border now stays inside it in all sizes

<img width="398" alt="image" src="https://github.com/user-attachments/assets/c3c13457-6c30-42cd-b66f-4ed13534395a">


<img width="460" alt="image" src="https://github.com/user-attachments/assets/3a6371c6-1b2a-484b-b005-c23f3413d675">


<img width="419" alt="image" src="https://github.com/user-attachments/assets/75bc2359-f944-4bf1-95b2-7133b4604cc1">
